### PR TITLE
chore: prettyprint long errors

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -18,6 +18,7 @@ import {
   logToFile,
   readline,
   logHeader,
+  prettyPrintError,
   OPEN_AI_CONFIG,
   WRAP_LIBRARY_URL,
   WRAP_LIBRARY_NAME
@@ -275,6 +276,8 @@ export class Agent {
   }
 }
 
+
+
 (async () => {
   try {
     const agent = await Agent.createAgent();
@@ -284,6 +287,6 @@ export class Agent {
       await agent.processUserPrompt(userInput)
     }
   } catch (e) {
-    console.log(e)
+    prettyPrintError(e)
   }
 })()

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,6 +1,7 @@
 import { ChatCompletionRequestMessage } from "openai";
 import winston from "winston";
 const figlet = require("figlet");
+import chalk from "chalk";
 
 const getLogFileName = () => {
   const date = new Date();
@@ -41,3 +42,15 @@ export const logHeader = () => {
     logger.info(data);
   });
 };
+
+export function prettyPrintError(error: any): void {
+  console.error(chalk.red('Something went wrong:'));
+  if (error.response) {
+    console.error(chalk.yellow('Response Status:'), chalk.blueBright(error.response.status));
+    console.error(chalk.yellow('Response Data:'), chalk.blueBright(JSON.stringify(error.response.data, null, 2)));
+  }
+  if (error.request) {
+    console.error(chalk.yellow('Request:'), chalk.blueBright(JSON.stringify(error.request, null, 2)));
+  }
+  console.error(chalk.yellow('Message:'), chalk.blueBright(error.message));
+}


### PR DESCRIPTION
Solves the issue where the errors from the agent would result in very long outputs that were unreadable, this fix prints a more readable error log with a description of what happened...
for example
![image](https://github.com/polywrap/agent-learning-demo/assets/12145726/5075b207-c436-4a92-8fd2-0fa49d7e6678)
