### PR TITLE
Rename LoadWrap to LearnWrap and add wrap description print

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -11,8 +11,8 @@ WRAP_LIBRARY_URL="https://raw.githubusercontent.com/polywrap/polygpt/dev/wrap-li
 WRAP_LIBRARY_NAME="polywrap/polygpt"
 
 # GPT_MODEL
-# choose between gpt-3.5-turbo-0613 and gpt-4-0613
-GPT_MODEL="gpt-3.5-turbo-0613"
+# choose between gpt-3.5-turbo-0613, gpt-3.5-turbo-16k-0613 and gpt-4-0613
+GPT_MODEL="gpt-3.5-turbo-16k-0613"
 
 # CONTEXT_WINDOW_TOKENS:
 # The size of the context window, used for the agent's short-term memory

--- a/.env.template
+++ b/.env.template
@@ -16,7 +16,7 @@ GPT_MODEL="gpt-3.5-turbo-16k-0613"
 
 # CONTEXT_WINDOW_TOKENS:
 # The size of the context window, used for the agent's short-term memory
-CONTEXT_WINDOW_TOKENS=4000
+CONTEXT_WINDOW_TOKENS=16000
 
 # MAX_TOKENS_PER_RESPONSE
 # The maximum size of the responses you'll get from the OpenAI model

--- a/.env.template
+++ b/.env.template
@@ -18,6 +18,11 @@ GPT_MODEL="gpt-3.5-turbo-0613"
 # The size of the context window, used for the agent's short-term memory
 CONTEXT_WINDOW_TOKENS=4000
 
+# MAX_TOKENS_PER_RESPONSE
+# The maximum size of the responses you'll get from the OpenAI model
+MAX_TOKENS_PER_RESPONSE=1000
+
+
 ################
 ### OPTIONAL ###
 ################

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -5,7 +5,7 @@ import {
 } from "./sys";
 import {
   WrapLibrary,
-    getWrapClient
+  getWrapClient
 } from "./wrap";
 import {
   Chat,
@@ -131,7 +131,6 @@ export class Agent {
       // Fetch the root "index" file
       const wrapIndex = await this._library.getIndex();
       this._wraps = await this._library.getWraps(wrapIndex.wraps);
-
 
       // Log the names of all known wraps and save the wrap descriptions
       const knownWraps = JSON.stringify(wrapIndex.wraps, null, 2);

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -75,7 +75,7 @@ export class Agent {
     agent._logger.logHeader();
 
     // Load wraps from library
-    await agent._loadWraps();
+    await agent._learnWraps();
 
     // Initialize the agent's chat
     agent._initializeChat();
@@ -120,7 +120,7 @@ export class Agent {
     }
   }
 
-  private async _loadWraps(): Promise<void> {
+  private async _learnWraps(): Promise<void> {
     this._logger.notice(
       `> Fetching wrap library index @ ${env().WRAP_LIBRARY_URL}\n`
     );

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -74,7 +74,7 @@ export class Agent {
     // Log agent header
     agent._logger.logHeader();
 
-    // Load wraps from library
+    // Learn wraps from library
     await agent._learnWraps();
 
     // Initialize the agent's chat
@@ -311,13 +311,13 @@ export class Agent {
       content: functionCallSummary
     };
 
-    if (name === "LoadWrap") {
+    if (name === "LearnWrap") {
       this._chat.add("persistent", {
         role: "system",
         content: `Loaded Wrap: ${args.name}`
       });
       this._chat.add("temporary", message);
-      this._logger.success(`> Loaded wrap: ${args?.name}\n`);
+      this._logger.success(`> 🧠 Learned a wrap: ${args?.name} \n`);
     } else {
       this._chat.add("temporary", message);
       this._logger.action(message);

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -5,7 +5,7 @@ import {
 } from "./sys";
 import {
   WrapLibrary,
-  getWrapClient
+    getWrapClient
 } from "./wrap";
 import {
   Chat,
@@ -35,7 +35,7 @@ export class Agent {
   private _wraps: WrapLibrary.Wrap[];
   private _library: WrapLibrary.Reader;
   private _client: PolywrapClient;
-  private _knownWraps: { [key: string]: string };
+  private _knownWraps: { [key: string]: {description: string, repo: string} };
   // If the agent executed a function last iteration
   private _executedLastIteration = false;
 
@@ -137,8 +137,8 @@ export class Agent {
       const knownWraps = JSON.stringify(wrapIndex.wraps, null, 2);
       this._logger.success(`Known Wraps:\n${knownWraps}`);
       for (let wrap of this._wraps) {
-        // Save the wrap and its description
-        this._knownWraps[wrap.name] = wrap.description;
+        // Save the wrap, its description and repo
+        this._knownWraps[wrap.name] = {"description":wrap.description, "repo":wrap.repo};
       }
     } catch (err) {
       this._logger.error("Failed to load wrap library.", err);
@@ -317,15 +317,21 @@ export class Agent {
     };
 
     if (name === "LearnWrap") {
+
+      interface WrapDescription {
+        description: string;
+        repo: string;
+      }
+
       // Retrieve the wrap description
-      const wrapDescription = this._knownWraps[args?.name] || 'No description available';
+      const wrapDescription: WrapDescription = this._knownWraps[args?.name] || 'No description available';
     
       this._chat.add("persistent", {
         role: "system",
         content: `Loaded Wrap: ${args.name}\nDescription: ${wrapDescription}`
       });
       this._chat.add("temporary", message);
-      this._logger.success(`\n> 🧠 Learned a wrap: ${args?.name}\nDescription: ${wrapDescription} \n`);
+      this._logger.success(`\n> 🧠 Learned a wrap: ${args?.name}\n> Description: ${wrapDescription["description"]} \n> Repo: ${wrapDescription["repo"]}\n`);
     } else {
       this._chat.add("temporary", message);
       this._logger.action(message);

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -316,6 +316,8 @@ export class Agent {
     };
 
     if (name === "LearnWrap") {
+      const wrapDescription = this._knownWraps[args?.name];
+
       this._chat.add("persistent", {
         role: "system",
         content: `Loaded Wrap: ${args.name}\nDescription: ${wrapDescription}`

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -215,7 +215,7 @@ export class Agent {
         messages: this._chat.messages,
         functions: functionDescriptions,
         temperature: 0,
-        max_tokens: 500
+        max_tokens: Number(env().OPENAI_API_KEY)
       });
 
       this._logger.spinner.stop();

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -108,7 +108,7 @@ export class Chat {
     }
 
     // Move onto "persistent" messages
-    await this._summarize("persistent");
+    //await this._summarize("persistent");
   }
 
   private _chunk(msg: Message): MessageLog {
@@ -161,6 +161,7 @@ export class Chat {
 
     const tokens = gpt2.encode(message.content || "").length;
 
+    console.log("HERERHERHERH", message.content, tokens);
     this._msgLogs[msgType] = {
       tokens,
       msgs: [message]

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -161,7 +161,6 @@ export class Chat {
 
     const tokens = gpt2.encode(message.content || "").length;
 
-    console.log("HERERHERHERH", message.content, tokens);
     this._msgLogs[msgType] = {
       tokens,
       msgs: [message]

--- a/src/openai.ts
+++ b/src/openai.ts
@@ -76,11 +76,11 @@ export const functionDescriptions = [
     },
   },
   {
-    name: "LoadWrap",
+    name: "LearnWrap",
     description: `A function to fetch the graphql schema for method analysis and introspection. 
                   It receives a wrap name.
                   For example
-                  Function = LoadWrap
+                  Function = LearnWrap
                   Arguments = Options {
                     name: <Wrap Name Here>
                   }`,
@@ -121,7 +121,7 @@ export const functions = (
       };
     }
   },
-  LoadWrap: async ({ name }: { name: string }) => {
+  LearnWrap: async ({ name }: { name: string }) => {
     try {
       const wrapInfo = await library.getWrap(name);
       const { data: wrapSchemaString } = await axios.get<string>(wrapInfo.abi);

--- a/src/sys/env.ts
+++ b/src/sys/env.ts
@@ -9,6 +9,7 @@ export interface Env {
   GPT_MODEL: string;
   CONTEXT_WINDOW_TOKENS: number;
   ETHEREUM_PRIVATE_KEY?: string;
+  MAX_TOKENS_PER_RESPONSE?: number;
 }
 
 let _env: Env | undefined;
@@ -30,7 +31,8 @@ export function env(): Env {
     WRAP_LIBRARY_NAME,
     GPT_MODEL,
     CONTEXT_WINDOW_TOKENS,
-    ETHEREUM_PRIVATE_KEY
+    ETHEREUM_PRIVATE_KEY,
+    MAX_TOKENS_PER_RESPONSE
   } = process.env;
 
   if (!OPENAI_API_KEY) {
@@ -48,6 +50,9 @@ export function env(): Env {
   if (!CONTEXT_WINDOW_TOKENS) {
     throw missingEnvError("CONTEXT_WINDOW_TOKENS");
   }
+  if (!MAX_TOKENS_PER_RESPONSE) {
+    throw missingEnvError("MAX_TOKENS_PER_RESPONSE");
+  }
 
   return {
     OPENAI_API_KEY,
@@ -55,6 +60,7 @@ export function env(): Env {
     WRAP_LIBRARY_NAME,
     GPT_MODEL,
     CONTEXT_WINDOW_TOKENS: Number(CONTEXT_WINDOW_TOKENS),
-    ETHEREUM_PRIVATE_KEY
+    ETHEREUM_PRIVATE_KEY,
+    MAX_TOKENS_PER_RESPONSE: Number(MAX_TOKENS_PER_RESPONSE)
   };
 }

--- a/src/wrap/client.ts
+++ b/src/wrap/client.ts
@@ -21,7 +21,13 @@ export function getWrapClient(
     .setPackage(
       Sys.bundle.fileSystem.uri,
       workspacePlugin(workspace)({}) as IWrapPackage
-    );
+    ) 
+    .addEnv("ipfs/Qmf9mRhNvKN1wfN52VdiZkjQiRw1WWEBYnwkuwzFg1ZjQn", { 
+      safeAddress: "0x0a083b47e4270be3467e16540380b130a6d9a09f", 
+      connection: { 
+        networkNameOrChainId: "goerli", 
+      },
+    });
 
   if (ethereumPrivateKey) {
     builder.setPackages({

--- a/src/wrap/library.ts
+++ b/src/wrap/library.ts
@@ -10,6 +10,7 @@ export namespace WrapLibrary {
     description: string;
     uri: string;
     abi: string;
+    repo: string;
     examplePrompts: {
       prompt: string;
       result: {
@@ -19,6 +20,8 @@ export namespace WrapLibrary {
       }
     }[]
   }
+
+
 
   export interface Wrap extends WrapData {
     name: string;

--- a/src/wrap/library.ts
+++ b/src/wrap/library.ts
@@ -21,8 +21,6 @@ export namespace WrapLibrary {
     }[]
   }
 
-
-
   export interface Wrap extends WrapData {
     name: string;
   }

--- a/wrap-library/ens.json
+++ b/wrap-library/ens.json
@@ -2,5 +2,7 @@
   "aliases": ["ens", "ethereum name service", ".eth"],
   "description": "The Ethereum Name Service (ENS) registry, enabling the reading & registration of .eth domains",
   "uri": "ipfs/QmbESzCRArrazFff9EbDeZ44fmENBZfVBkG7AMrAvjevQL",
-  "abi": "https://raw.githubusercontent.com/polywrap/ens/main/src/schema.graphql"
+  "abi": "https://raw.githubusercontent.com/polywrap/ens/main/src/schema.graphql",
+  "repo": "https://github.com/polywrap/ens"
+
 }

--- a/wrap-library/ethers.json
+++ b/wrap-library/ethers.json
@@ -3,6 +3,7 @@
   "description": "Interact with the ethereum blockchain",
   "uri": "ipfs/QmNkqWQuTAiZaLSR3VE53uazuAEqZevv1XQtvAYahuyJ6d",
   "abi": "https://raw.githubusercontent.com/polywrap/ethers/main/wraps/core/polywrap.graphql",
+  "repo": "https://github.com/polywrap/ethers",
   "hints":[
     "Always leave the connection arguments empty like so: 'connection': {}",
     "The 'sendTransaction' method requires a 'data' property on the 'tx' object parameter."

--- a/wrap-library/ethers.json
+++ b/wrap-library/ethers.json
@@ -2,7 +2,7 @@
   "aliases": ["ethereum", "eth", "ether", "ethers"],
   "description": "Interact with the ethereum blockchain",
   "uri": "ipfs/QmNkqWQuTAiZaLSR3VE53uazuAEqZevv1XQtvAYahuyJ6d",
-  "abi": "https://raw.githubusercontent.com/polywrap/ens/main/polywrap.graphql",
+  "abi": "https://raw.githubusercontent.com/polywrap/ens/1c370243ca9d75905c360e1ab4b09f69d3eb7a70/polywrap.graphql",
   "repo": "https://github.com/polywrap/ethers",
   "hints":[
     "Always leave the connection arguments empty like so: 'connection': {}",

--- a/wrap-library/ethers.json
+++ b/wrap-library/ethers.json
@@ -2,7 +2,7 @@
   "aliases": ["ethereum", "eth", "ether", "ethers"],
   "description": "Interact with the ethereum blockchain",
   "uri": "ipfs/QmNkqWQuTAiZaLSR3VE53uazuAEqZevv1XQtvAYahuyJ6d",
-  "abi": "https://raw.githubusercontent.com/polywrap/ethers/main/wraps/core/polywrap.graphql",
+  "abi": "hhttps://raw.githubusercontent.com/polywrap/ens/main/polywrap.graphql",
   "repo": "https://github.com/polywrap/ethers",
   "hints":[
     "Always leave the connection arguments empty like so: 'connection': {}",

--- a/wrap-library/ethers.json
+++ b/wrap-library/ethers.json
@@ -2,7 +2,7 @@
   "aliases": ["ethereum", "eth", "ether", "ethers"],
   "description": "Interact with the ethereum blockchain",
   "uri": "ipfs/QmNkqWQuTAiZaLSR3VE53uazuAEqZevv1XQtvAYahuyJ6d",
-  "abi": "hhttps://raw.githubusercontent.com/polywrap/ens/main/polywrap.graphql",
+  "abi": "https://raw.githubusercontent.com/polywrap/ens/main/polywrap.graphql",
   "repo": "https://github.com/polywrap/ethers",
   "hints":[
     "Always leave the connection arguments empty like so: 'connection': {}",

--- a/wrap-library/filesystem.json
+++ b/wrap-library/filesystem.json
@@ -3,6 +3,7 @@
   "description": "Interact with the operating system's filesystem.",
   "uri": "plugin/file-system@1.0.0",
   "abi": "https://raw.githubusercontent.com/polywrap/file-system/main/interface/polywrap.graphql",
+  "repo": "https://github.com/polywrap/file-system",
   "hints": [
     "When writing text to a file using the writeFile function, you do not need to encode the text"
   ],

--- a/wrap-library/http.json
+++ b/wrap-library/http.json
@@ -2,5 +2,6 @@
   "aliases": [],
   "description": "Perform HTTP calls",
   "uri": "plugin/http@1.1.0",
-  "abi": "https://raw.githubusercontent.com/polywrap/http/main/interface/polywrap.graphql"
+  "abi": "https://raw.githubusercontent.com/polywrap/http/main/interface/polywrap.graphql",
+  "repo": "https://github.com/polywrap/http"
 }

--- a/wrap-library/index.json
+++ b/wrap-library/index.json
@@ -1,3 +1,5 @@
 {
   "wraps": ["ethers", "http", "ipfs", "filesystem", "web-scraper", "ens", "safe-factory", "safe-manager"]
 }
+
+Look up my ethereum address,  then create an ethereum transaction to send 10% of my funds to the 0x0a083b47e4270be3467e16540380b130a6d9a09f gnosis safe, finally use the safe manager wrap to create a transaction to send that back to me. You'll need to create the transaction, sign it and then approve it. Please begin with a simple step by step plan of what you are going to do before executing it.

--- a/wrap-library/index.json
+++ b/wrap-library/index.json
@@ -1,3 +1,4 @@
 {
   "wraps": ["ethers", "http", "ipfs", "filesystem", "web-scraper", "ens", "safe-factory", "safe-manager"]
 }
+

--- a/wrap-library/index.json
+++ b/wrap-library/index.json
@@ -1,5 +1,3 @@
 {
   "wraps": ["ethers", "http", "ipfs", "filesystem", "web-scraper", "ens", "safe-factory", "safe-manager"]
 }
-
-Look up my ethereum address,  then create an ethereum transaction to send 10% of my funds to the 0x0a083b47e4270be3467e16540380b130a6d9a09f gnosis safe, finally use the safe manager wrap to create a transaction to send that back to me. You'll need to create the transaction, sign it and then approve it. Please begin with a simple step by step plan of what you are going to do before executing it.

--- a/wrap-library/index.json
+++ b/wrap-library/index.json
@@ -1,3 +1,3 @@
 {
-  "wraps": ["ethers", "http", "ipfs", "filesystem", "web-scraper", "ens", "safe-factory"]
+  "wraps": ["ethers", "http", "ipfs", "filesystem", "web-scraper", "ens", "safe-factory", "safe-manager"]
 }

--- a/wrap-library/ipfs.json
+++ b/wrap-library/ipfs.json
@@ -2,5 +2,7 @@
   "aliases": [],
   "description": "Interact with IPFS",
   "uri": "embed/ipfs-http-client@1.0.0",
-  "abi": "https://raw.githubusercontent.com/polywrap/ipfs/main/wrappers/ipfs-http-client/src/schema.graphql"
+  "abi": "https://raw.githubusercontent.com/polywrap/ipfs/main/wrappers/ipfs-http-client/src/schema.graphql",
+  "repo": "https://github.com/polywrap/ipfs"
+
 }

--- a/wrap-library/safe-factory.json
+++ b/wrap-library/safe-factory.json
@@ -2,5 +2,7 @@
   "aliases": ["safe", "safe creation", "safe deployment", "safe deploy"],
   "description": "The Gnosis Safe Factory wrap allows you to deploy Safes from any environment.",
   "uri": "ipfs/QmR7yiQv5jULzZ8ysHbCtjMowLiuiv2hX6Z4DiyfdQd5Pp",
-  "abi": "https://raw.githubusercontent.com/polywrap/safe-contracts-wrapper/main/packages/safe-factory-wrapper/src/schema.graphql"
+  "abi": "https://raw.githubusercontent.com/polywrap/safe-contracts-wrapper/main/packages/safe-factory-wrapper/src/schema.graphql",
+  "repo": "https://github.com/polywrap/safe-contracts-wrapper"
+
 }

--- a/wrap-library/safe-manager.json
+++ b/wrap-library/safe-manager.json
@@ -4,5 +4,4 @@
     "uri": "ipfs/Qmf9mRhNvKN1wfN52VdiZkjQiRw1WWEBYnwkuwzFg1ZjQn",
     "abi": "https://raw.githubusercontent.com/polywrap/safe-contracts-wrapper/main/packages/safe-managers-wrapper/src/schema.graphql",
     "repo": "https://github.com/polywrap/safe-contracts-wrapper"
-
   }

--- a/wrap-library/safe-manager.json
+++ b/wrap-library/safe-manager.json
@@ -1,0 +1,8 @@
+{
+    "aliases": ["safe manager", "safe management"],
+    "description": "The Gnosis Safe Manager wrap allows you to interact with safes that have already been deployed with the safe-deplploy wrap.",
+    "uri": "ipfs/Qmf9mRhNvKN1wfN52VdiZkjQiRw1WWEBYnwkuwzFg1ZjQn",
+    "abi": "https://raw.githubusercontent.com/polywrap/safe-contracts-wrapper/main/packages/safe-managers-wrapper/src/schema.graphql",
+    "repo": "https://github.com/polywrap/safe-contracts-wrapper"
+
+  }

--- a/wrap-library/web-scraper.json
+++ b/wrap-library/web-scraper.json
@@ -2,5 +2,7 @@
   "aliases": ["internet", "scraper"],
   "description": "Query the internet and scrape its contents",
   "uri": "ipfs/QmXKA6qc3TMiBZn5DyydYwdc9o2uSShqFdV7yTgYjF2xdu",
-  "abi": "https://raw.githubusercontent.com/polywrap/web-scraper/master/polywrap.graphql"
+  "abi": "https://raw.githubusercontent.com/polywrap/web-scraper/master/polywrap.graphql",
+  "repo": "https://github.com/polywrap/web-scraper"
+
 }


### PR DESCRIPTION
This renames the LoadWrap Functionality into LearnWrap,

We have included a print of the wrap description and the repo so the user can inspect the wrap, this will enhance the experience by allowing devs to dig into the repo of the wrap and potentially improve it.

tested by running several agent prompts and using the autopilot mode

![image](https://github.com/polywrap/PolyGPT/assets/12145726/ede9071a-a57f-4963-b6e0-f202c8c34604)

This also adds the 16k token model as default 
