### PR TITLE
Set the `gpt-3.5-turbo-16k-0613` as the default model with 16k token window

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -11,8 +11,8 @@ WRAP_LIBRARY_URL="https://raw.githubusercontent.com/polywrap/polygpt/dev/wrap-li
 WRAP_LIBRARY_NAME="polywrap/polygpt"
 
 # GPT_MODEL
-# choose between gpt-3.5-turbo-0613 and gpt-4-0613
-GPT_MODEL="gpt-3.5-turbo-0613"
+# choose between gpt-3.5-turbo-16k-0613, gpt-4-0613 and gpt-3.5-turbo-0613
+GPT_MODEL="gpt-3.5-turbo-16k-0613"
 
 # CONTEXT_WINDOW_TOKENS:
 # The size of the context window, used for the agent's short-term memory

--- a/README.md
+++ b/README.md
@@ -71,7 +71,9 @@ PolyGPT keeps an up-to-date version of all messages being sent to the OpenAI API
 
 ## GPT-4
 
-While using the `gpt-3.5-turbo-0613` model will work, we highly recommend using the `gpt-4-0613` model. It will double the context window size to 8k tokens. The GPT 4 model will be available to more accounts [soon](https://openai.com/blog/gpt-4-api-general-availability).
+While using the `gpt-3.5-turbo-0613` model will work, we highly recommend using the `gpt-4-0613` model or the `gpt-3.5-turbo-16k-0613` model. They will increase the context window size to 8k tokens. 
+
+While the GPT 4 model will be available to more accounts [soon](https://openai.com/blog/gpt-4-api-general-availability), the `gpt-3.5-turbo-16k-0613` model should be generally available.
 
 ## Ethereum Integrations
 


### PR DESCRIPTION
Now that the model gpt-3.5-turbo-16k-0613 is generally available, we should be able to set it as default, improving the general ux