### PR TITLE
Fix: functionToCall is not a function

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -11,8 +11,8 @@ WRAP_LIBRARY_URL="https://raw.githubusercontent.com/polywrap/polygpt/dev/wrap-li
 WRAP_LIBRARY_NAME="polywrap/polygpt"
 
 # GPT_MODEL
-# choose between gpt-3.5-turbo-16k-0613, gpt-4-0613 and gpt-3.5-turbo-0613
-GPT_MODEL="gpt-3.5-turbo-16k-0613"
+# currently only gpt-4-0613 is supported
+GPT_MODEL="gpt-4-0613"
 
 # CONTEXT_WINDOW_TOKENS:
 # The size of the context window, used for the agent's short-term memory

--- a/README.md
+++ b/README.md
@@ -69,11 +69,12 @@ Logs are printed to the console, and to a new file for each run within the `./ch
 
 PolyGPT keeps an up-to-date version of all messages being sent to the OpenAI API in the `./workspace/.msgs` file. All of these messages will be sent to OpenAI on each chat completion. This is useful because as the message log grows, summarizations are performed upon the message history to fit them within a maximum context window token limit.
 
-## GPT-4
+## Model
 
-While using the `gpt-3.5-turbo-0613` model will work, we highly recommend using the `gpt-4-0613` model or the `gpt-3.5-turbo-16k-0613` model. They will increase the context window size to 8k tokens. 
+The model runs on the OpenAI functions API. Also, due to hallucinations coming from the GPT 3.5 model, we have only enabled `gpt-4-0613` model by default. This model also has a context window length of 8k tokens. GPT 3.5 is still used for chunking and summarization
 
-While the GPT 4 model will be available to more accounts [soon](https://openai.com/blog/gpt-4-api-general-availability), the `gpt-3.5-turbo-16k-0613` model should be generally available.
+The GPT 4 model is available for previous users of the OpenAI API who have paid at least one billing cycle. [More info](https://openai.com/blog/gpt-4-api-general-availability)
+
 
 ## Ethereum Integrations
 

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -283,7 +283,10 @@ export class Agent {
     ? JSON.parse(functionCall.arguments)
     : undefined;
 
-    const functionToCall = (functions(this._library, this._client) as any)[name];
+    const functionToCall = (functions(
+      this._library, 
+      this._client
+    ) as any)[name];
 
     if (typeof functionToCall !== 'function') {
       this._logMessage("system", `Function ${name} is not defined in PolyGPT, only "LearnWrap" and "InvokeWrap" can be called.`);

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -274,14 +274,14 @@ export class Agent {
   ): Promise<void> {
     const name = functionCall.name!;
     const args = functionCall.arguments
-    ? JSON.parse(functionCall.arguments)
-    : undefined;
+      ? JSON.parse(functionCall.arguments)
+      : undefined;
 
     const functionToCall = (functions(
-      this._library, 
+      this._library,
       this._client
     ) as any)[name];
-    
+
     const response = await functionToCall(args);
 
     this._executedLastIteration = true;

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -280,17 +280,17 @@ export class Agent {
   ): Promise<void> {
     const name = functionCall.name!;
     const args = functionCall.arguments
-      ? JSON.parse(functionCall.arguments)
-      : undefined;
+    ? JSON.parse(functionCall.arguments)
+    : undefined;
 
-      const functionToCall = (functions(this._library, this._client) as any)[name];
+    const functionToCall = (functions(this._library, this._client) as any)[name];
 
-      if (typeof functionToCall !== 'function') {
-        this._logMessage("system", `Function ${name} is not defined in PolyGPT, only "LearnWrap" and "InvokeWrap" can be called.`);
-        return;
-      }
-      
-      const response = await functionToCall(args);
+    if (typeof functionToCall !== 'function') {
+      this._logMessage("system", `Function ${name} is not defined in PolyGPT, only "LearnWrap" and "InvokeWrap" can be called.`);
+      return;
+    }
+    
+    const response = await functionToCall(args);
 
     this._executedLastIteration = true;
 

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -281,11 +281,6 @@ export class Agent {
       this._library, 
       this._client
     ) as any)[name];
-
-    if (typeof functionToCall !== 'function') {
-      this._logMessage("system", `Function ${name} is not defined in PolyGPT, only "LearnWrap" and "InvokeWrap" can be called.`);
-      return;
-    }
     
     const response = await functionToCall(args);
 

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -283,12 +283,14 @@ export class Agent {
       ? JSON.parse(functionCall.arguments)
       : undefined;
 
-    const functionToCall = (functions(
-      this._library,
-      this._client
-    ) as any)[name];
+      const functionToCall = (functions(this._library, this._client) as any)[name];
 
-    const response = await functionToCall(args);
+      if (typeof functionToCall !== 'function') {
+        this._logMessage("system", `Function ${name} is not defined in PolyGPT, only "LearnWrap" and "InvokeWrap" can be called.`);
+        return;
+      }
+      
+      const response = await functionToCall(args);
 
     this._executedLastIteration = true;
 

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -108,7 +108,7 @@ export class Chat {
     }
 
     // Move onto "persistent" messages
-    //await this._summarize("persistent");
+    await this._summarize("persistent");
   }
 
   private _chunk(msg: Message): MessageLog {
@@ -198,6 +198,7 @@ export class Chat {
       // Summarize
       const response = await this._openai.createChatCompletion({
         messages: toSummarize,
+        model: "gpt-3.5-turbo-16k-0613",
         temperature: 0,
         max_tokens: this._summaryTokens
       });

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -21,6 +21,16 @@ Follow these rules:
 - When a WrapError is encountered, figure out why it happened and fix the problem.
 - Only call the functions InvokeWrap and LearnWrap.
 
+For example: 
+InvokeWrap ({
+  "uri": "<wrapUriHere>",
+  "method": "<methodNameHere>",
+  "args": {
+    "domain": "<domainHere>",
+    "connection": {}
+  }
+})
+
 Here are the wraps that are available for you to load:
 ${JSON.stringify(wraps)}`
   }

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -21,14 +21,11 @@ Follow these rules:
 - When a WrapError is encountered, figure out why it happened and fix the problem.
 - Only call the functions InvokeWrap and LearnWrap.
 
-For example: 
+- Take this function call for example: 
 InvokeWrap ({
   "uri": "<wrapUriHere>",
   "method": "<methodNameHere>",
-  "args": {
-    "domain": "<domainHere>",
-    "connection": {}
-  }
+  "args": {...}
 })
 
 Here are the wraps that are available for you to load:

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -13,11 +13,13 @@ You do this by loading new "wraps", and invoking the functions within them.
 Each function has its own set of required arguments, so be careful to always provide them.
 
 Follow these rules:
+- Always load a wrap before invoking a function from it.
 - Only load a wrap once.
 - Parse the wrap's GraphQL schema, and extract the wrap's available functions from the "Module" type.
 - Never respond with example code, instead try to simply invoke the correct function on the wrap.
 - Always provide arguments as raw JSON objects that can be parsed.
 - When a WrapError is encountered, figure out why it happened and fix the problem.
+- Only call the functions InvokeWrap and LearnWrap.
 
 Here are the wraps that are available for you to load:
 ${JSON.stringify(wraps)}`

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -19,14 +19,6 @@ Follow these rules:
 - Never respond with example code, instead try to simply invoke the correct function on the wrap.
 - Always provide arguments as raw JSON objects that can be parsed.
 - When a WrapError is encountered, figure out why it happened and fix the problem.
-- Only call the functions InvokeWrap and LearnWrap.
-
-- Take this function call for example: 
-InvokeWrap ({
-  "uri": "<wrapUriHere>",
-  "method": "<methodNameHere>",
-  "args": {...}
-})
 
 Here are the wraps that are available for you to load:
 ${JSON.stringify(wraps)}`


### PR DESCRIPTION
This patches issue #45 

The 3.5 16k model was hallucinating functions that it didnt have

tested by running the same prompt mentioned in the issue and it worked this time consistently.